### PR TITLE
Add Playwright troubleshooting, local-run scripts, demo UI, and implementation package

### DIFF
--- a/Cats/index.html
+++ b/Cats/index.html
@@ -1,0 +1,466 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>EFL Student Data Entry Prototype</title>
+  <style>
+    :root {
+      --bg: #f3f6fb;
+      --card: #ffffff;
+      --ink: #1f2937;
+      --muted: #64748b;
+      --brand: #2563eb;
+      --ok: #16a34a;
+      --warn: #f59e0b;
+      --danger: #dc2626;
+      --radius: 14px;
+    }
+    * { box-sizing: border-box; }
+    body { font-family: Inter, Arial, sans-serif; margin: 0; background: var(--bg); color: var(--ink); }
+    header { background: linear-gradient(135deg, #0f172a, #1e293b); color: #fff; padding: 14px 18px; }
+    h1 { font-size: 1.25rem; margin: 0; }
+    .subtitle { margin-top: 6px; font-size: .92rem; color: #dbeafe; }
+
+    .shell { max-width: 1200px; margin: 0 auto; padding: 12px; }
+    .topbar {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(150px, 1fr));
+      gap: 10px;
+      background: #fff;
+      padding: 12px;
+      border-radius: var(--radius);
+      box-shadow: 0 2px 6px rgba(15, 23, 42, 0.07);
+      margin-bottom: 10px;
+    }
+    .topbar > * { width: 100%; }
+
+    select, input, textarea, button {
+      min-height: 46px;
+      padding: 10px 12px;
+      border: 1px solid #cbd5e1;
+      border-radius: 10px;
+      font-size: 16px;
+    }
+    select, input, textarea { background: #fff; }
+    button { cursor: pointer; background: #eef2ff; font-weight: 600; }
+    button.primary { background: var(--brand); color: white; border-color: var(--brand); }
+    button.success { background: var(--ok); color: white; border-color: var(--ok); }
+
+    .badge {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 600;
+      border-radius: 999px;
+      border: 1px solid #cbd5e1;
+      background: #ecfeff;
+      min-height: 46px;
+    }
+
+    .helper {
+      background: #fffbeb;
+      border: 1px solid #fef08a;
+      color: #92400e;
+      padding: 10px;
+      border-radius: 10px;
+      margin-bottom: 10px;
+      font-size: .95rem;
+    }
+
+    .tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+    .tab { border: none; background: #e2e8f0; }
+    .tab.active { background: var(--brand); color: #fff; }
+
+    .panel { display: none; }
+    .panel.active { display: block; }
+
+    .card {
+      background: var(--card);
+      border-radius: var(--radius);
+      box-shadow: 0 2px 6px rgba(15, 23, 42, 0.07);
+      padding: 14px;
+      margin-bottom: 12px;
+    }
+
+    .card h3 { margin-top: 0; margin-bottom: 8px; }
+    .row { display: grid; grid-template-columns: repeat(4, minmax(130px, 1fr)); gap: 8px; margin-bottom: 10px; }
+    .roster-row { display: grid; grid-template-columns: 1.6fr repeat(4, 1fr); gap: 8px; margin-bottom: 8px; align-items: center; }
+    .rubric-row { display: grid; grid-template-columns: 1.6fr repeat(4, 1fr) 1fr; gap: 8px; margin-bottom: 8px; align-items: center; }
+
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 10px; }
+    .tiny { font-size: .88rem; color: var(--muted); margin-top: 0; }
+    .pill { background: #eff6ff; border: 1px solid #bfdbfe; color: #1d4ed8; border-radius: 999px; padding: 3px 8px; font-size: .8rem; }
+
+    .sticky-actions {
+      position: sticky;
+      bottom: 8px;
+      background: rgba(255,255,255,.95);
+      backdrop-filter: blur(4px);
+      border: 1px solid #e2e8f0;
+      padding: 10px;
+      border-radius: 12px;
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      z-index: 10;
+    }
+
+    @media (max-width: 980px) {
+      .topbar { grid-template-columns: 1fr 1fr; }
+      .row, .roster-row, .rubric-row { grid-template-columns: 1fr; }
+      .badge { justify-content: flex-start; padding-left: 12px; }
+    }
+  </style>
+</head>
+<body>
+<header>
+  <h1>📘 EFL Data Entry Assistant</h1>
+  <div class="subtitle">Fast, teacher-friendly entry for attendance, behavior, and broader English rubrics.</div>
+</header>
+
+<div class="shell">
+  <div class="topbar">
+    <select id="schoolYear"><option>2026-2027</option></select>
+    <select id="classSel"><option>Grade 7 - A</option><option>Grade 7 - B</option></select>
+    <select id="subjectSel"><option>English</option><option>Math</option><option>Science</option></select>
+    <input id="dateSel" type="date" />
+    <div class="badge" id="onlineBadge">🟢 Online</div>
+  </div>
+
+  <div class="helper">
+    💡 <strong>Teacher speed tip:</strong> Filter student names, use bigger drop-downs, and save offline if the internet is unstable.
+  </div>
+
+  <div class="tabs">
+    <button class="tab active" data-panel="attendance">Attendance</button>
+    <button class="tab" data-panel="grades">Grades & Rubrics</button>
+    <button class="tab" data-panel="behavior">Behavior</button>
+    <button class="tab" data-panel="family">Family Feedback</button>
+    <button class="tab" data-panel="sync">Sync Status</button>
+  </div>
+
+  <section id="attendance" class="panel active">
+    <div class="card">
+      <h3>Attendance Roster</h3>
+      <p class="tiny">Mark all present first, then only edit exceptions.</p>
+      <input id="attendanceFilter" placeholder="Search student..." oninput="renderAttendance()" />
+      <div id="attendanceRoster"></div>
+      <div class="sticky-actions">
+        <button onclick="markAllPresent()">Mark all Present</button>
+        <button onclick="saveAttendanceDraft()">Save Draft (offline)</button>
+        <button class="primary" onclick="submitAttendance()">Submit & Sync</button>
+      </div>
+    </div>
+  </section>
+
+  <section id="grades" class="panel">
+    <div class="card">
+      <h3>English Assessment Setup</h3>
+      <div class="row">
+        <input id="assessmentTitle" placeholder="Assessment title" value="Mid-term speaking task" />
+        <select id="assessmentType"><option>oral</option><option>exam</option><option>quiz</option><option>homework</option><option>project</option></select>
+        <input id="maxScore" type="number" placeholder="Max score" value="20" />
+        <button onclick="loadGradeRows()">Load Students</button>
+      </div>
+      <div id="gradeGrid"></div>
+      <div class="actions"><button class="primary" onclick="saveGrades()">Save Numeric Grades</button></div>
+    </div>
+
+    <div class="card">
+      <h3>🗣️ Oral Production Rubric <span class="pill">EFL</span></h3>
+      <p class="tiny">Criteria: Fluency, Grammatical Precision, Pronunciation, Content & Coherence (1–5 each).</p>
+      <input id="oralFilter" placeholder="Search student..." oninput="renderRubrics()" />
+      <div id="oralRubricGrid"></div>
+      <div class="actions"><button class="success" onclick="saveOralRubrics()">Save Oral Rubrics</button></div>
+    </div>
+
+    <div class="card">
+      <h3>✍️ Written Production Rubric <span class="pill">EFL</span></h3>
+      <p class="tiny">Criteria: Task Achievement, Organization, Grammar Accuracy, Vocabulary Range (1–5 each).</p>
+      <div id="writtenRubricGrid"></div>
+      <div class="actions"><button class="success" onclick="saveWrittenRubrics()">Save Written Rubrics</button></div>
+    </div>
+  </section>
+
+  <section id="behavior" class="panel">
+    <div class="card">
+      <h3>Behavior Record</h3>
+      <p class="tiny">Use quick ratings to keep data entry under 30 seconds per student.</p>
+      <div class="row">
+        <select id="behaviorStudent"></select>
+        <input id="participation" type="number" min="1" max="5" placeholder="Participation 1-5" />
+        <input id="attitude" type="number" min="1" max="5" placeholder="Attitude 1-5" />
+        <input id="punctuality" type="number" min="1" max="5" placeholder="Punctuality 1-5" />
+      </div>
+      <div class="row">
+        <select id="severity"><option>none</option><option>minor</option><option>moderate</option><option>major</option></select>
+        <input id="context" placeholder="Incident context" />
+        <input id="followup" placeholder="Follow-up action" />
+        <button class="primary" onclick="saveBehavior()">Save Behavior</button>
+      </div>
+    </div>
+  </section>
+
+  <section id="family" class="panel">
+    <div class="card">
+      <h3>Family Feedback</h3>
+      <div class="row">
+        <select id="familyStudent"></select>
+        <input id="engagement" type="number" min="1" max="5" placeholder="Engagement 1-5" />
+        <input id="satisfaction" type="number" min="1" max="5" placeholder="Satisfaction 1-5" />
+        <input id="communication" type="number" min="1" max="5" placeholder="Communication 1-5" />
+      </div>
+      <textarea id="familyComment" rows="3" style="width:100%" placeholder="Open comment"></textarea>
+      <div class="actions"><button class="primary" onclick="saveFamily()">Save Feedback</button></div>
+    </div>
+  </section>
+
+  <section id="sync" class="panel">
+    <div class="card">
+      <h3>Sync Status</h3>
+      <p>Pending queue: <strong id="queueCount">0</strong></p>
+      <p>Last sync: <strong id="lastSync">Never</strong></p>
+      <div class="actions">
+        <button onclick="toggleOnline()">Toggle Online/Offline</button>
+        <button onclick="syncNow()">Sync now</button>
+        <button onclick="clearAllData()">Clear local data</button>
+      </div>
+    </div>
+  </section>
+</div>
+
+<script>
+const students = ["Amina Yusuf","David Stone","Lina Cruz","Musa Ali","Sara Khan","Rosa Pérez","Yuki Tanaka"];
+const roster = document.getElementById('attendanceRoster');
+const dateSel = document.getElementById('dateSel');
+dateSel.valueAsDate = new Date();
+let online = true;
+
+const rubricOptions = [
+  '<option value="">-</option>',
+  '<option value="1">1 - Emerging</option>',
+  '<option value="2">2 - Developing</option>',
+  '<option value="3">3 - Competent</option>',
+  '<option value="4">4 - Strong</option>',
+  '<option value="5">5 - Excellent</option>'
+].join('');
+
+function setupTabs(){
+  document.querySelectorAll('.tab').forEach(btn => {
+    btn.onclick = () => {
+      document.querySelectorAll('.tab').forEach(b=>b.classList.remove('active'));
+      document.querySelectorAll('.panel').forEach(p=>p.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.panel).classList.add('active');
+    }
+  });
+}
+
+function uuid(){ return crypto.randomUUID ? crypto.randomUUID() : String(Date.now()+Math.random()); }
+function getQueue(){ return JSON.parse(localStorage.getItem('syncQueue') || '[]'); }
+function setQueue(q){ localStorage.setItem('syncQueue', JSON.stringify(q)); updateSyncUI(); }
+function enqueue(type, payload){ const q=getQueue(); q.push({id:uuid(), type, payload, createdAt:new Date().toISOString()}); setQueue(q); }
+function filteredStudents(inputId){
+  const q = (document.getElementById(inputId)?.value || '').toLowerCase().trim();
+  return students.filter(s => s.toLowerCase().includes(q));
+}
+
+function renderAttendance(){
+  const list = filteredStudents('attendanceFilter');
+  roster.innerHTML = list.map(name => `
+    <div class="roster-row" data-name="${name}">
+      <strong>${name}</strong>
+      <select class="status"><option>present</option><option>absent</option><option>tardy</option></select>
+      <select class="absenceType"><option value="">absence type</option><option>excused</option><option>unexcused</option></select>
+      <input class="minutesLate" type="number" min="0" placeholder="minutes late" />
+      <span class="tiny">Quick entry</span>
+    </div>`).join('');
+}
+
+function markAllPresent(){
+  document.querySelectorAll('.status').forEach(s => s.value='present');
+}
+
+function collectAttendance(){
+  const records=[];
+  let valid=true;
+  document.querySelectorAll('#attendanceRoster .roster-row').forEach(row=>{
+    const status=row.querySelector('.status').value;
+    const absenceType=row.querySelector('.absenceType').value;
+    const minutesLate=row.querySelector('.minutesLate').value;
+    if(status==='absent' && !absenceType) valid=false;
+    if(status==='tardy' && (minutesLate==='' || Number(minutesLate)<0)) valid=false;
+    records.push({
+      client_record_uuid: uuid(),
+      student_name: row.dataset.name,
+      attendance_date: dateSel.value,
+      status,
+      absence_type: status==='absent'?absenceType:null,
+      minutes_late: status==='tardy'?Number(minutesLate):null
+    });
+  });
+  return {valid, records};
+}
+
+function saveAttendanceDraft(){
+  const data=collectAttendance();
+  if(!data.valid){ alert('Please fill absence type/minutes late correctly.'); return; }
+  localStorage.setItem('attendanceDraft', JSON.stringify(data.records));
+  enqueue('attendance', data.records);
+  alert('Attendance draft saved locally.');
+}
+
+function submitAttendance(){
+  const data=collectAttendance();
+  if(!data.valid){ alert('Please fill absence type/minutes late correctly.'); return; }
+  if(!online){ enqueue('attendance', data.records); alert('Offline: queued for sync.'); return; }
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Attendance submitted (simulated).');
+  updateSyncUI();
+}
+
+function loadGradeRows(){
+  const max = Number(document.getElementById('maxScore').value||0);
+  const grid = document.getElementById('gradeGrid');
+  grid.innerHTML = students.map(s=>`<div class="roster-row"><strong>${s}</strong><input type="number" class="g" min="0" max="${max}" placeholder="score / ${max}"/><input class="c" placeholder="comment"/><span class="tiny">Range 0-${max}</span><span></span></div>`).join('');
+}
+
+function saveGrades(){
+  const max = Number(document.getElementById('maxScore').value||0);
+  const rows = [...document.querySelectorAll('#gradeGrid .roster-row')];
+  const payload = rows.map(r=>({client_record_uuid:uuid(),student_name:r.querySelector('strong').innerText,score:Number(r.querySelector('.g').value),comment:r.querySelector('.c').value}));
+  if(payload.some(p=>Number.isNaN(p.score) || p.score<0 || p.score>max)){ alert('Invalid score range.'); return; }
+  if(!online){ enqueue('grades', payload); alert('Grades queued (offline).'); return; }
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Grades saved (simulated).');
+  updateSyncUI();
+}
+
+function rubricRow(name, type){
+  return `<div class="rubric-row" data-name="${name}" data-type="${type}">
+      <strong>${name}</strong>
+      <select class="r1">${rubricOptions}</select>
+      <select class="r2">${rubricOptions}</select>
+      <select class="r3">${rubricOptions}</select>
+      <select class="r4">${rubricOptions}</select>
+      <input class="rtotal" placeholder="Total" readonly />
+    </div>`;
+}
+
+function computeRubricTotals(){
+  document.querySelectorAll('.rubric-row').forEach(row => {
+    const vals = ['.r1','.r2','.r3','.r4'].map(c => Number(row.querySelector(c).value || 0));
+    const total = vals.reduce((a,b)=>a+b,0);
+    row.querySelector('.rtotal').value = total ? `${total}/20` : '';
+  });
+}
+
+function renderRubrics(){
+  const oralList = filteredStudents('oralFilter');
+  document.getElementById('oralRubricGrid').innerHTML = oralList.map(s => rubricRow(s,'oral')).join('');
+  document.getElementById('writtenRubricGrid').innerHTML = students.map(s => rubricRow(s,'written')).join('');
+  document.querySelectorAll('.rubric-row select').forEach(el => el.onchange = computeRubricTotals);
+}
+
+function collectRubrics(type){
+  const rows = [...document.querySelectorAll(`.rubric-row[data-type="${type}"]`)];
+  const payload = rows.map(r => ({
+    client_record_uuid: uuid(),
+    student_name: r.dataset.name,
+    c1: Number(r.querySelector('.r1').value||0),
+    c2: Number(r.querySelector('.r2').value||0),
+    c3: Number(r.querySelector('.r3').value||0),
+    c4: Number(r.querySelector('.r4').value||0)
+  }));
+  return payload.filter(p => p.c1+p.c2+p.c3+p.c4 > 0);
+}
+
+function saveOralRubrics(){
+  const payload = collectRubrics('oral').map(p => ({...p, rubric: {fluency:p.c1, grammatical_precision:p.c2, pronunciation:p.c3, content_coherence:p.c4}}));
+  if(!payload.length){ alert('No oral rubric entries to save yet.'); return; }
+  if(!online){ enqueue('oral_rubrics', payload); alert('Oral rubrics queued (offline).'); return; }
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Oral rubrics saved (simulated).');
+  updateSyncUI();
+}
+
+function saveWrittenRubrics(){
+  const payload = collectRubrics('written').map(p => ({...p, rubric: {task_achievement:p.c1, organization:p.c2, grammar_accuracy:p.c3, vocabulary_range:p.c4}}));
+  if(!payload.length){ alert('No written rubric entries to save yet.'); return; }
+  if(!online){ enqueue('written_rubrics', payload); alert('Written rubrics queued (offline).'); return; }
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Written rubrics saved (simulated).');
+  updateSyncUI();
+}
+
+function fillStudentSelectors(){
+  const opts = students.map(s=>`<option>${s}</option>`).join('');
+  document.getElementById('behaviorStudent').innerHTML = opts;
+  document.getElementById('familyStudent').innerHTML = opts;
+}
+
+function saveBehavior(){
+  const p = Number(document.getElementById('participation').value);
+  const a = Number(document.getElementById('attitude').value);
+  const pu = Number(document.getElementById('punctuality').value);
+  if([p,a,pu].some(v => v<1 || v>5 || Number.isNaN(v))){ alert('Ratings must be 1 to 5.'); return; }
+  const payload={client_record_uuid:uuid(),student:document.getElementById('behaviorStudent').value,participation:p,attitude:a,punctuality:pu,severity:document.getElementById('severity').value,context:document.getElementById('context').value,followup:document.getElementById('followup').value};
+  if(!online){ enqueue('behavior', payload); alert('Behavior queued (offline).'); return; }
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Behavior saved (simulated).');
+  updateSyncUI();
+}
+
+function saveFamily(){
+  const e = Number(document.getElementById('engagement').value);
+  const s = Number(document.getElementById('satisfaction').value);
+  const c = Number(document.getElementById('communication').value);
+  if([e,s,c].some(v => v<1 || v>5 || Number.isNaN(v))){ alert('Ratings must be 1 to 5.'); return; }
+  const payload={client_record_uuid:uuid(),student:document.getElementById('familyStudent').value,engagement:e,satisfaction:s,communication:c,comment:document.getElementById('familyComment').value};
+  if(!online){ enqueue('family_feedback', payload); alert('Feedback queued (offline).'); return; }
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Family feedback saved (simulated).');
+  updateSyncUI();
+}
+
+function toggleOnline(){
+  online=!online;
+  const badge = document.getElementById('onlineBadge');
+  badge.innerText = online ? '🟢 Online' : '🔴 Offline';
+  badge.style.background = online ? '#dcfce7' : '#fee2e2';
+  badge.style.borderColor = online ? '#bbf7d0' : '#fecaca';
+}
+
+function syncNow(){
+  if(!online){ alert('You are offline.'); return; }
+  const q=getQueue();
+  if(!q.length){ alert('Queue empty.'); return; }
+  setQueue([]);
+  localStorage.setItem('lastSync', new Date().toLocaleString());
+  alert('Queued items synced (simulated).');
+  updateSyncUI();
+}
+
+function clearAllData(){
+  localStorage.removeItem('syncQueue');
+  localStorage.removeItem('attendanceDraft');
+  localStorage.removeItem('lastSync');
+  updateSyncUI();
+  alert('Local demo data cleared.');
+}
+
+function updateSyncUI(){
+  document.getElementById('queueCount').innerText = getQueue().length;
+  document.getElementById('lastSync').innerText = localStorage.getItem('lastSync') || 'Never';
+}
+
+setupTabs();
+renderAttendance();
+fillStudentSelectors();
+updateSyncUI();
+loadGradeRows();
+renderRubrics();
+</script>
+</body>
+</html>

--- a/Cats/index.html
+++ b/Cats/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>EFL Student Data Entry Prototype</title>
+  <!-- Conflict-resolved baseline: includes UX + EFL oral/written rubrics -->
   <style>
     :root {
       --bg: #f3f6fb;
@@ -129,7 +130,7 @@
   </div>
 
   <div class="helper">
-    💡 <strong>Teacher speed tip:</strong> Filter student names, use bigger drop-downs, and save offline if the internet is unstable.
+    💡 <strong>Teacher speed tip:</strong> Filter student names, use bigger drop-downs, and save offline if the internet is unstable. EFL rubrics now track fluency, grammar precision, pronunciation, and coherence.
   </div>
 
   <div class="tabs">

--- a/IMPLEMENTATION_PACKAGE.md
+++ b/IMPLEMENTATION_PACKAGE.md
@@ -1,0 +1,813 @@
+# Data-Driven Education App: Implementation Package
+
+This document provides:
+1. A concrete PostgreSQL schema (DDL).
+2. A minimal API contract.
+3. Exact UI form structures optimized for fast teacher data entry on web + mobile.
+4. Beginner-friendly fix for: `rg --files -g 'AGENTS.md'` returning no files.
+
+---
+
+## 1) PostgreSQL Schema (DDL)
+
+> Notes:
+> - Uses UUID primary keys.
+> - Uses strict constraints for data quality.
+> - Separates core entities from event records.
+> - Ready for online/offline sync with `client_record_uuid` and timestamps.
+
+```sql
+-- Enable UUID generation
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- =========================
+-- Core org/school structure
+-- =========================
+
+CREATE TABLE schools (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'UTC',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE classes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  school_id UUID NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  grade_level SMALLINT NOT NULL CHECK (grade_level BETWEEN 1 AND 12),
+  school_year TEXT NOT NULL, -- e.g. 2026-2027
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(school_id, name, school_year)
+);
+
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  school_id UUID NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('teacher','admin','counselor','principal')),
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL,
+  email TEXT NOT NULL UNIQUE,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE teacher_class_assignments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  teacher_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  class_id UUID NOT NULL REFERENCES classes(id) ON DELETE CASCADE,
+  subject TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(teacher_id, class_id, subject)
+);
+
+-- =========================
+-- Student model
+-- =========================
+
+CREATE TABLE students (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  school_id UUID NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  external_student_id TEXT NOT NULL,
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL,
+  date_of_birth DATE,
+  gender TEXT,
+  language_preference TEXT,
+  enrollment_status TEXT NOT NULL DEFAULT 'active' CHECK (enrollment_status IN ('active','inactive','graduated','transferred')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(school_id, external_student_id)
+);
+
+CREATE TABLE student_class_enrollments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  student_id UUID NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  class_id UUID NOT NULL REFERENCES classes(id) ON DELETE CASCADE,
+  start_date DATE NOT NULL,
+  end_date DATE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(student_id, class_id, start_date)
+);
+
+-- =========================
+-- Academic model
+-- =========================
+
+CREATE TABLE subjects (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  school_id UUID NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  code TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(school_id, code)
+);
+
+CREATE TABLE grading_periods (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  school_id UUID NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,              -- Term 1, Semester 1, etc.
+  start_date DATE NOT NULL,
+  end_date DATE NOT NULL,
+  CHECK (start_date <= end_date),
+  UNIQUE(school_id, label, start_date)
+);
+
+CREATE TABLE assessments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  class_id UUID NOT NULL REFERENCES classes(id) ON DELETE CASCADE,
+  subject_id UUID NOT NULL REFERENCES subjects(id) ON DELETE RESTRICT,
+  grading_period_id UUID REFERENCES grading_periods(id) ON DELETE SET NULL,
+  assessment_type TEXT NOT NULL CHECK (assessment_type IN ('exam','quiz','homework','project','oral','other')),
+  title TEXT NOT NULL,
+  max_score NUMERIC(6,2) NOT NULL CHECK (max_score > 0),
+  assessment_date DATE NOT NULL,
+  created_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE grade_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_record_uuid UUID NOT NULL,
+  student_id UUID NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  assessment_id UUID NOT NULL REFERENCES assessments(id) ON DELETE CASCADE,
+  score NUMERIC(6,2) NOT NULL CHECK (score >= 0),
+  comment TEXT,
+  entered_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  entered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(student_id, assessment_id),
+  UNIQUE(client_record_uuid)
+);
+
+CREATE TABLE skill_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_record_uuid UUID NOT NULL,
+  student_id UUID NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  grading_period_id UUID NOT NULL REFERENCES grading_periods(id) ON DELETE CASCADE,
+  reading_score NUMERIC(5,2) CHECK (reading_score BETWEEN 0 AND 100),
+  writing_score NUMERIC(5,2) CHECK (writing_score BETWEEN 0 AND 100),
+  listening_score NUMERIC(5,2) CHECK (listening_score BETWEEN 0 AND 100),
+  speaking_score NUMERIC(5,2) CHECK (speaking_score BETWEEN 0 AND 100),
+  term_average NUMERIC(5,2) CHECK (term_average BETWEEN 0 AND 100),
+  entered_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  entered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(student_id, grading_period_id),
+  UNIQUE(client_record_uuid)
+);
+
+-- =========================
+-- Attendance model
+-- =========================
+
+CREATE TABLE attendance_records (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_record_uuid UUID NOT NULL,
+  student_id UUID NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  class_id UUID NOT NULL REFERENCES classes(id) ON DELETE CASCADE,
+  attendance_date DATE NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('present','absent','tardy')),
+  absence_type TEXT CHECK (absence_type IN ('excused','unexcused')),
+  minutes_late SMALLINT CHECK (minutes_late >= 0),
+  note TEXT,
+  entered_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  entered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(student_id, class_id, attendance_date),
+  UNIQUE(client_record_uuid)
+);
+
+-- =========================
+-- Behavior model
+-- =========================
+
+CREATE TABLE behavior_records (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_record_uuid UUID NOT NULL,
+  student_id UUID NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  class_id UUID REFERENCES classes(id) ON DELETE SET NULL,
+  event_date DATE NOT NULL,
+  participation_rating SMALLINT CHECK (participation_rating BETWEEN 1 AND 5),
+  attitude_rating SMALLINT CHECK (attitude_rating BETWEEN 1 AND 5),
+  punctuality_rating SMALLINT CHECK (punctuality_rating BETWEEN 1 AND 5),
+  incident_severity TEXT CHECK (incident_severity IN ('none','minor','moderate','major')),
+  incident_context TEXT,
+  follow_up_action TEXT,
+  entered_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  entered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(client_record_uuid)
+);
+
+-- =========================
+-- Family feedback model
+-- =========================
+
+CREATE TABLE family_feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_record_uuid UUID NOT NULL,
+  student_id UUID NOT NULL REFERENCES students(id) ON DELETE CASCADE,
+  feedback_date DATE NOT NULL,
+  engagement_rating SMALLINT CHECK (engagement_rating BETWEEN 1 AND 5),
+  satisfaction_rating SMALLINT CHECK (satisfaction_rating BETWEEN 1 AND 5),
+  communication_rating SMALLINT CHECK (communication_rating BETWEEN 1 AND 5),
+  open_comment TEXT,
+  submitted_by_name TEXT,
+  submitted_by_relation TEXT,
+  entered_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  entered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(client_record_uuid)
+);
+
+-- =========================
+-- Sync and audit helpers
+-- =========================
+
+CREATE TABLE sync_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  device_id TEXT NOT NULL,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  payload_count INTEGER NOT NULL CHECK (payload_count >= 0),
+  success_count INTEGER NOT NULL CHECK (success_count >= 0),
+  failed_count INTEGER NOT NULL CHECK (failed_count >= 0),
+  synced_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  entity_name TEXT NOT NULL,
+  entity_id UUID NOT NULL,
+  action TEXT NOT NULL CHECK (action IN ('create','update','delete','view_sensitive')),
+  changed_fields JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_attendance_student_date ON attendance_records(student_id, attendance_date);
+CREATE INDEX idx_behavior_student_date ON behavior_records(student_id, event_date);
+CREATE INDEX idx_grade_student_assessment ON grade_entries(student_id, assessment_id);
+CREATE INDEX idx_feedback_student_date ON family_feedback(student_id, feedback_date);
+```
+
+---
+
+## 2) Minimal API Contract (REST)
+
+Base URL: `/api/v1`
+Auth: `Authorization: Bearer <JWT>`
+
+### 2.1 Common rules
+
+- Every write request includes `client_record_uuid` for idempotency (offline-safe).
+- Server responds with `server_received_at`, `record_id`, and validation issues if any.
+- Validation errors use `422 Unprocessable Entity`.
+
+Standard error format:
+
+```json
+{
+  "error": "validation_error",
+  "message": "Score must be between 0 and max_score",
+  "field_errors": {
+    "score": ["must be <= 20"]
+  }
+}
+```
+
+### 2.2 Essential endpoints
+
+#### Auth/User context
+- `POST /auth/login`
+- `GET /me`
+
+#### Reference data
+- `GET /schools/:schoolId/classes?teacher_id=...`
+- `GET /schools/:schoolId/students?class_id=...`
+- `GET /schools/:schoolId/subjects`
+- `GET /schools/:schoolId/grading-periods`
+
+#### Academic
+- `POST /assessments`
+- `POST /grade-entries/bulk`
+- `POST /skill-scores/bulk`
+
+`POST /grade-entries/bulk` request example:
+```json
+{
+  "assessment_id": "5d8e9f53-1d9b-4f95-9a01-2c5eb77ab120",
+  "entries": [
+    {
+      "client_record_uuid": "20ea7459-42d9-4c6f-81d0-0f0e1885c4f1",
+      "student_id": "e8eb5cc5-c18b-4f8f-a7f1-3c05e86d1b5f",
+      "score": 16.5,
+      "comment": "Strong progress"
+    }
+  ]
+}
+```
+
+#### Attendance
+- `POST /attendance/bulk`
+- `GET /attendance?class_id=...&date=...`
+
+`POST /attendance/bulk` request example:
+```json
+{
+  "class_id": "f8477a6a-3686-4f86-8a1d-6c3378f3ddf8",
+  "attendance_date": "2026-09-14",
+  "records": [
+    {
+      "client_record_uuid": "d1f9e4f8-59be-4ad8-8b28-a1b9f0cd4e7d",
+      "student_id": "e8eb5cc5-c18b-4f8f-a7f1-3c05e86d1b5f",
+      "status": "tardy",
+      "absence_type": null,
+      "minutes_late": 10,
+      "note": "Bus delay"
+    }
+  ]
+}
+```
+
+#### Behavior
+- `POST /behavior-records`
+- `POST /behavior-records/bulk`
+- `GET /behavior-records?student_id=...&from=...&to=...`
+
+#### Family feedback
+- `POST /family-feedback`
+- `GET /family-feedback?student_id=...`
+
+#### Sync
+- `POST /sync/push`
+- `POST /sync/pull`
+
+`POST /sync/push` request example:
+```json
+{
+  "device_id": "tablet-room-4",
+  "last_synced_at": "2026-09-14T08:10:00Z",
+  "changes": {
+    "attendance_records": [],
+    "grade_entries": [],
+    "behavior_records": [],
+    "family_feedback": []
+  }
+}
+```
+
+---
+
+## 3) Exact UI Form Structure (Teacher Speed: Web + Mobile)
+
+Design objective: complete core classroom entry tasks in <2 minutes/class.
+
+### 3.1 Navigation pattern
+
+- Top-level tabs (both web/mobile):
+  1. **Attendance**
+  2. **Grades**
+  3. **Behavior**
+  4. **Family Feedback**
+  5. **Sync Status**
+
+- Class selector pinned at top: `School Year` → `Class` → `Subject`.
+- Date picker defaults to today.
+
+### 3.2 Attendance form (fast roster mode)
+
+**Layout:** one-row-per-student roster.
+
+Fields per row:
+- Student name (read-only)
+- Status segmented control: `Present | Absent | Tardy`
+- If Absent: absence type chips `Excused | Unexcused`
+- If Tardy: numeric input `Minutes late`
+- Optional note icon opens short text area
+
+Fast actions:
+- `Mark all Present`
+- `Apply previous day pattern`
+- Keyboard shortcuts (web): `P/A/T`, arrow down next student
+- Swipe actions (mobile): right=present, left=absent
+
+Validation:
+- `minutes_late` required if status=tardy
+- `absence_type` required if status=absent
+
+CTA buttons:
+- `Save Draft (offline)`
+- `Submit & Sync`
+
+### 3.3 Grades form (assessment + bulk scores)
+
+**Step 1: Assessment header card**
+- Subject (dropdown)
+- Assessment type (exam/quiz/homework/project/oral/other)
+- Title
+- Date
+- Max score
+
+**Step 2: Student score grid**
+Per student row:
+- Score input (numeric)
+- Quick rubric chips (optional): `Below`, `Basic`, `Proficient`, `Advanced`
+- Comment icon for short note
+
+Validation:
+- Score must be `0 <= score <= max_score`
+- highlight out-of-range instantly
+
+Fast actions:
+- Autofill repeated value
+- Paste-from-clipboard (web)
+- Next-empty navigation
+
+### 3.4 Academic skills form (reading/writing/listening/speaking)
+
+Fields per student:
+- Reading score (0–100)
+- Writing score (0–100)
+- Listening score (0–100)
+- Speaking score (0–100)
+- Term average (auto-calculated, editable with reason)
+
+Section behavior:
+- Collapsible “Skill details” under each student
+- Batch mode: apply same score range template if needed
+
+### 3.5 Behavior form
+
+Per student event card:
+- Date
+- Participation rating (1–5 stars)
+- Attitude rating (1–5)
+- Punctuality rating (1–5)
+- Incident severity (`None/Minor/Moderate/Major`)
+- Incident context (short text)
+- Follow-up action (short text)
+
+Fast actions:
+- “Positive note quick add” template chips
+- Duplicate last record for next student
+
+### 3.6 Family feedback form
+
+Fields:
+- Student
+- Feedback date
+- Engagement rating (1–5)
+- Satisfaction rating (1–5)
+- Communication rating (1–5)
+- Open comment
+- Submitted by name + relation
+
+Input widgets:
+- Sliders or segmented buttons for ratings
+- voice-to-text on mobile for comments (optional)
+
+### 3.7 Sync status screen (must-have for offline trust)
+
+Panels:
+- Connectivity: `Online` / `Offline`
+- Queue count by module (Attendance/Grades/Behavior/Feedback)
+- Last successful sync timestamp
+- Conflict count + “Resolve now” action
+- Retry button
+
+Conflict UX:
+- Show server vs local value side-by-side
+- Button: `Keep Local` / `Keep Server`
+- Save resolution to audit log
+
+---
+
+## 4) Beginner-Friendly Fix for `rg --files -g 'AGENTS.md'` returning none
+
+### What this means
+This is **not really an error**. It simply means there is currently no file named `AGENTS.md` inside your repository path.
+
+### Step-by-step checks
+
+1. Confirm your current folder:
+```bash
+pwd
+```
+You should be in your project root.
+
+2. Check whether any `AGENTS.md` exists in this repo:
+```bash
+rg --files -g 'AGENTS.md'
+```
+If it prints nothing, none exists here.
+
+3. Search one level above (if instructions might be outside repo):
+```bash
+find .. -maxdepth 3 -name 'AGENTS.md'
+```
+
+4. If you need one, create it in the repo root:
+```bash
+cat > AGENTS.md <<'EOF'
+# AGENTS.md
+Project-specific instructions for coding agents.
+EOF
+```
+
+5. Verify again:
+```bash
+rg --files -g 'AGENTS.md'
+```
+Now it should return `AGENTS.md`.
+
+### Common beginner mistakes
+- Running the command from the wrong directory.
+- Typo in filename (`Agent.md`, `agents.md`, etc.).
+- Expecting every repo to already include an `AGENTS.md`.
+
+---
+
+## 5) Suggested next implementation order (1 week sprint)
+
+1. Create DB with DDL above.
+2. Implement auth + reference endpoints.
+3. Implement attendance bulk endpoint + roster UI.
+4. Implement grades assessment + bulk entry.
+5. Add local storage queue + `/sync/push`.
+6. Add behavior/family forms.
+7. Add sync status + conflict UI.
+8. Add audit logging + role restrictions.
+
+
+---
+
+## 6) Next Steps to Visualize the App and Test It (Beginner-Friendly)
+
+This section assumes you want the **fastest path** to actually see screens running and test end-to-end.
+
+### 6.1 Choose a starter stack (simple and practical)
+
+Use this stack first:
+- Frontend (web + mobile-friendly): **React + Vite + PWA**
+- Backend API: **Node.js + Express + TypeScript**
+- Database: **PostgreSQL**
+- Local tools: **Docker Desktop** + **VS Code**
+
+Why this stack?
+- Easy to start.
+- Huge tutorials/community.
+- Works well with offline-first patterns.
+
+### 6.2 Install required tools (one-time setup)
+
+1. Install **Git**.
+2. Install **Node.js LTS** (includes npm).
+3. Install **Docker Desktop**.
+4. Install **VS Code**.
+5. Optional but useful: install **Postman** (for API testing).
+
+Quick checks (run in terminal):
+```bash
+git --version
+node --version
+npm --version
+docker --version
+```
+
+If any command fails, install that tool first and retry.
+
+### 6.3 Create project folders
+
+From your project root:
+```bash
+mkdir -p app/frontend app/backend app/infra
+```
+
+Result:
+- `app/frontend` for React UI
+- `app/backend` for API
+- `app/infra` for Docker + DB setup
+
+### 6.4 Start PostgreSQL with Docker (local database)
+
+Create file: `app/infra/docker-compose.yml`
+
+```yaml
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16
+    container_name: edu_postgres
+    environment:
+      POSTGRES_USER: edu_user
+      POSTGRES_PASSWORD: edu_pass
+      POSTGRES_DB: edu_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+```
+
+Start database:
+```bash
+cd app/infra
+docker compose up -d
+docker compose ps
+```
+
+You should see container `edu_postgres` running.
+
+### 6.5 Apply the schema (DDL)
+
+1. Copy the SQL DDL section (from this document) into `app/infra/schema.sql`.
+2. Run:
+```bash
+docker exec -i edu_postgres psql -U edu_user -d edu_db < app/infra/schema.sql
+```
+
+Verify tables created:
+```bash
+docker exec -it edu_postgres psql -U edu_user -d edu_db -c "\dt"
+```
+
+### 6.6 Build and run backend API
+
+Create backend app:
+```bash
+cd /workspace/hello-world/app/backend
+npm init -y
+npm install express cors helmet pg zod dotenv
+npm install -D typescript ts-node-dev @types/node @types/express
+npx tsc --init
+```
+
+Create `.env` in `app/backend`:
+```env
+PORT=4000
+DATABASE_URL=postgresql://edu_user:edu_pass@localhost:5432/edu_db
+JWT_SECRET=replace_me
+```
+
+Create minimal server file (`src/server.ts`) with:
+- `GET /api/v1/health` → returns `{ ok: true }`
+- `POST /api/v1/attendance/bulk`
+- `POST /api/v1/grade-entries/bulk`
+
+Run backend:
+```bash
+npm run dev
+```
+
+If no script exists, add to `package.json`:
+```json
+"scripts": {
+  "dev": "ts-node-dev --respawn --transpile-only src/server.ts"
+}
+```
+
+Test health endpoint:
+```bash
+curl http://localhost:4000/api/v1/health
+```
+
+### 6.7 Build and run frontend (visualize the app)
+
+Create frontend app:
+```bash
+cd /workspace/hello-world/app/frontend
+npm create vite@latest . -- --template react-ts
+npm install
+npm install react-router-dom
+```
+
+Start frontend:
+```bash
+npm run dev
+```
+
+Open browser at the URL shown (usually `http://localhost:5173`).
+
+Create first screens:
+- `/attendance`
+- `/grades`
+- `/behavior`
+- `/family-feedback`
+- `/sync-status`
+
+For each screen, start with static form fields exactly as defined in Section 3.
+
+### 6.8 Connect frontend to backend
+
+1. In frontend, create an API service file (example: `src/services/api.ts`).
+2. Set backend base URL to `http://localhost:4000/api/v1`.
+3. On attendance form submit:
+   - collect rows
+   - call `POST /attendance/bulk`
+4. Show success message if HTTP 200/201.
+5. Show inline error messages for HTTP 422.
+
+### 6.9 Add basic offline mode (first working version)
+
+Beginner approach:
+1. If API call fails (network issue), store payload in IndexedDB.
+2. Show badge in UI: “Pending sync: X”.
+3. Add “Sync now” button in Sync Status screen.
+4. When online, send queued payloads to `/sync/push`.
+
+Test offline flow:
+- Turn off Wi-Fi.
+- Submit attendance.
+- Confirm record saved locally (queue count increases).
+- Turn Wi-Fi on.
+- Press “Sync now”.
+- Confirm queue decreases to zero.
+
+### 6.10 Manual testing checklist (beginner-friendly)
+
+Run these tests in order:
+
+1. **Database test**
+   - Can connect to PostgreSQL.
+   - `\dt` lists expected tables.
+
+2. **API health test**
+   - `GET /health` returns ok.
+
+3. **Attendance API test**
+   - Submit one valid payload.
+   - Confirm row appears in `attendance_records`.
+
+4. **Validation test**
+   - Send invalid status (e.g. `lateeee`).
+   - Confirm API returns 422 and error message.
+
+5. **Frontend visual test**
+   - Screen loads.
+   - Fields are visible and grouped correctly.
+
+6. **Frontend submit test**
+   - Submit form; confirm success toast/message.
+
+7. **Offline queue test**
+   - Submit while offline.
+   - Confirm pending count.
+   - Reconnect and sync.
+
+8. **Conflict test (later)**
+   - Edit same record on two devices.
+   - Confirm conflict appears in Sync Status.
+
+### 6.11 SQL checks to confirm data really saved
+
+Attendance by date:
+```sql
+SELECT student_id, class_id, attendance_date, status, absence_type, minutes_late
+FROM attendance_records
+ORDER BY attendance_date DESC
+LIMIT 50;
+```
+
+Grades by assessment:
+```sql
+SELECT student_id, assessment_id, score
+FROM grade_entries
+ORDER BY entered_at DESC
+LIMIT 50;
+```
+
+### 6.12 Common beginner errors and fixes
+
+1. **Backend can’t connect to DB**
+   - Check container is running: `docker compose ps`
+   - Check `DATABASE_URL` values.
+
+2. **CORS error in browser**
+   - Enable CORS middleware in Express.
+
+3. **Frontend says Network Error**
+   - Confirm backend port is 4000 and running.
+   - Confirm base URL is correct.
+
+4. **SQL schema fails**
+   - Ensure `pgcrypto` extension line is included.
+   - Re-run on a clean database if needed.
+
+5. **No data after submit**
+   - Check API logs.
+   - Run SQL query directly to verify insert.
+
+### 6.13 Definition of “ready for pilot”
+
+You are ready to pilot in one classroom when:
+- Attendance for a full class can be submitted in <2 minutes.
+- Grade bulk entry works for at least 30 students.
+- Offline save + later sync works reliably.
+- Validation catches bad inputs in real time.
+- Teacher can complete daily workflow without developer help.

--- a/README.md
+++ b/README.md
@@ -145,3 +145,50 @@ curl -I http://127.0.0.1:8095/Cats/
 ```
 
 If `curl` is 200 but Playwright still fails, it is usually a browser-container connectivity issue, not an app code issue.
+
+
+---
+
+## If GitHub says this branch has conflicts in `Cats/index.html` or `README.md`
+
+Use these exact commands locally:
+
+```zsh
+cd /workspace/hello-world
+git status
+```
+
+1. Update your branch with the latest target branch (example: `main`):
+
+```zsh
+git fetch origin
+git merge origin/main
+```
+
+2. If conflicts appear, open the files and remove conflict markers:
+- `<<<<<<<`
+- `=======`
+- `>>>>>>>`
+
+Keep the combined final content you want.
+
+3. Verify no conflict markers remain:
+
+```zsh
+rg "^(<<<<<<<|=======|>>>>>>>)" Cats/index.html README.md
+```
+
+4. Finalize resolution:
+
+```zsh
+git add Cats/index.html README.md
+git commit -m "Resolve merge conflicts in Cats/index.html and README.md"
+```
+
+5. Push your branch again:
+
+```zsh
+git push
+```
+
+If step 3 returns no output, conflicts are fully resolved.

--- a/README.md
+++ b/README.md
@@ -192,3 +192,33 @@ git push
 ```
 
 If step 3 returns no output, conflicts are fully resolved.
+
+
+---
+
+## Conflict resolution outcome for `Cats/index.html` and `README.md`
+
+The merge conflicts you pasted are resolved by keeping the **EFL-enhanced version** and dropping only conflict markers.
+
+Chosen final baseline includes:
+- EFL UI title and expanded teacher-friendly layout.
+- Oral rubric criteria: fluency, grammatical precision, pronunciation, content/coherence.
+- Written rubric criteria: task achievement, organization, grammar accuracy, vocabulary range.
+- Larger controls and improved UX helpers.
+
+Validation command (must return no output):
+
+```zsh
+rg "^(<<<<<<<|=======|>>>>>>>)" Cats/index.html README.md
+```
+
+If you still see conflicts on GitHub after local resolution, run:
+
+```zsh
+git fetch origin
+git merge origin/main
+rg "^(<<<<<<<|=======|>>>>>>>)" Cats/index.html README.md
+git add Cats/index.html README.md
+git commit -m "Resolve merge conflicts in Cats/index.html and README.md"
+git push
+```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,147 @@
 # hello-world
-## My name is Guillermo. This is my first repository.
-### Ready for the ride?
-**This is bold**
-~~ Mistaken text ~~
-*** Bold and italic ***
-> quote
-'''
-git status
-git add
-git commit 
-'''
+
+## Start the app (quick)
+
+From repository root:
+
+```zsh
+./run_app.sh
+```
+
+Open:
+- `http://localhost:8080/Cats/`
+
+---
+
+## Fix for this error
+
+If you see:
+
+```text
+zsh: no such file or directory: ./scripts/run_app.sh
+```
+
+it usually means you are not inside the project folder.
+
+### Step-by-step fix (beginner)
+
+1. Check where you are now:
+   ```zsh
+   pwd
+   ```
+
+2. Go to the repository folder:
+   ```zsh
+   cd /workspace/hello-world
+   ```
+
+3. Check the script exists:
+   ```zsh
+   ls -la scripts
+   ```
+   You should see `run_app.sh` in the list.
+
+4. Start the app with the new root shortcut:
+   ```zsh
+   ./run_app.sh
+   ```
+
+5. If the script is still missing, your local copy may be incomplete.
+   Re-download or re-clone:
+   ```zsh
+   cd /workspace
+   rm -rf hello-world
+   git clone https://github.com/<your-user>/<your-repo>.git hello-world
+   cd hello-world
+   ./run_app.sh
+   ```
+
+---
+
+## Verify repository structure
+
+Run:
+
+```zsh
+./scripts/check_repo.zsh
+```
+
+This checks required files:
+- `Cats/index.html`
+- `scripts/run_app.sh`
+- `scripts/test_app.sh`
+- `README.md`
+- `IMPLEMENTATION_PACKAGE.md`
+
+---
+
+## Test app quickly
+
+```zsh
+./scripts/test_app.sh
+```
+
+---
+
+## Notes
+- This is a front-end prototype with simulated sync behavior.
+- Backend/database details are in `IMPLEMENTATION_PACKAGE.md`.
+
+
+---
+
+## Fix for Playwright screenshot error (`ERR_EMPTY_RESPONSE`)
+
+If you see this during automated screenshots:
+
+```text
+mcp__browser_tools__run_playwright_script ... ERR_EMPTY_RESPONSE
+```
+
+it usually means the browser tool could not reach your local server at that moment.
+
+### Why this happens
+- The server process stopped before Playwright connected.
+- The server was started in a way that ended when the shell command finished.
+- Wrong port was forwarded or wrong URL/host was used.
+- Another process already occupied the port.
+
+### Reliable fix (step by step)
+
+1. Start server in a persistent terminal:
+   ```zsh
+   cd /workspace/hello-world
+   python3 -m http.server 8095 --directory /workspace/hello-world
+   ```
+
+2. In another terminal, verify server is reachable:
+   ```zsh
+   curl -I http://127.0.0.1:8095/Cats/
+   ```
+   You should get `HTTP/1.0 200 OK`.
+
+3. In Playwright/browser tool, forward the same port (`8095`).
+
+4. Use one of these URLs in the script:
+   - `http://127.0.0.1:8095/Cats/`
+   - `http://localhost:8095/Cats/`
+
+5. If it still fails, test direct file route:
+   - `http://127.0.0.1:8095/Cats/index.html`
+
+6. If needed, change to a clean port:
+   ```zsh
+   python3 -m http.server 8096 --directory /workspace/hello-world
+   ```
+   Then forward/use `8096` in Playwright.
+
+### Quick diagnostics checklist
+
+```zsh
+pwd
+ls -la /workspace/hello-world/Cats/index.html
+lsof -i :8095
+curl -I http://127.0.0.1:8095/Cats/
+```
+
+If `curl` is 200 but Playwright still fails, it is usually a browser-container connectivity issue, not an app code issue.

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -x "./scripts/run_app.sh" ]]; then
+  exec ./scripts/run_app.sh "$@"
+fi
+
+echo "❌ Could not find ./scripts/run_app.sh"
+echo "You are probably not in the repository root."
+echo "Try:"
+echo "  cd /workspace/hello-world"
+echo "  ls -la scripts"
+echo "  ./scripts/run_app.sh"
+exit 1

--- a/scripts/check_repo.zsh
+++ b/scripts/check_repo.zsh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+echo "Checking repository at: ${REPO_ROOT}"
+
+if [[ ! -d "${REPO_ROOT}/.git" ]]; then
+  echo "❌ .git directory not found in ${REPO_ROOT}"
+  exit 1
+fi
+
+required_paths=(
+  "${REPO_ROOT}/Cats"
+  "${REPO_ROOT}/Cats/index.html"
+  "${REPO_ROOT}/scripts"
+  "${REPO_ROOT}/scripts/run_app.sh"
+  "${REPO_ROOT}/scripts/test_app.sh"
+  "${REPO_ROOT}/README.md"
+  "${REPO_ROOT}/IMPLEMENTATION_PACKAGE.md"
+)
+
+for p in "${required_paths[@]}"; do
+  if [[ -e "$p" ]]; then
+    echo "✅ Found: $p"
+  else
+    echo "❌ Missing: $p"
+    exit 1
+  fi
+done
+
+echo "✅ Repository structure looks correct."

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${1:-8080}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ ! -f "${REPO_ROOT}/Cats/index.html" ]]; then
+  echo "Could not find ${REPO_ROOT}/Cats/index.html"
+  echo "Make sure you're running inside the repository."
+  exit 1
+fi
+
+echo "Serving repo root: ${REPO_ROOT}"
+echo "Open: http://localhost:${PORT}/Cats/"
+python3 -m http.server "${PORT}" --directory "${REPO_ROOT}"

--- a/scripts/setup_repo_folder.sh
+++ b/scripts/setup_repo_folder.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_ROOT="${1:-$HOME/workspace}"
+REPO_NAME="hello-world"
+TARGET_DIR="${TARGET_ROOT}/${REPO_NAME}"
+
+mkdir -p "${TARGET_ROOT}"
+echo "✅ Workspace folder ready: ${TARGET_ROOT}"
+
+if [[ -d "${TARGET_DIR}/.git" ]]; then
+  echo "✅ Repository already exists: ${TARGET_DIR}"
+  exit 0
+fi
+
+echo "Repository not found at: ${TARGET_DIR}"
+echo "Next step: clone your repo into that folder, e.g.:"
+echo "  git clone https://github.com/<your-user>/<your-repo>.git ${TARGET_DIR}"

--- a/scripts/test_app.sh
+++ b/scripts/test_app.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${1:-8080}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BASE_URL="http://127.0.0.1:${PORT}/Cats/"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ ! -f "${REPO_ROOT}/Cats/index.html" ]]; then
+  echo "Missing ${REPO_ROOT}/Cats/index.html"
+  exit 1
+fi
+
+echo "[1/4] Starting local web server on port ${PORT} from ${REPO_ROOT}..."
+python3 -m http.server "$PORT" --directory "${REPO_ROOT}" >/tmp/edu_app_server.log 2>&1 &
+SERVER_PID=$!
+sleep 1
+
+echo "[2/4] Checking app URL responds..."
+HTTP_STATUS=$(curl -s -o /tmp/edu_app_index.html -w "%{http_code}" "$BASE_URL")
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "Expected HTTP 200 from ${BASE_URL}, got ${HTTP_STATUS}"
+  echo "Tip: open http://127.0.0.1:${PORT}/Cats/index.html directly to confirm path."
+  exit 1
+fi
+
+echo "[3/4] Checking key UI sections in HTML..."
+for token in "Attendance" "Grades" "Behavior" "Family Feedback" "Sync Status"; do
+  if ! grep -q "$token" /tmp/edu_app_index.html; then
+    echo "Missing expected UI section: $token"
+    exit 1
+  fi
+done
+
+echo "[4/4] Smoke test passed ✅"
+echo "You can now open ${BASE_URL} in your browser."


### PR DESCRIPTION
### Motivation
- Provide a clear, beginner-friendly fix for the `mcp__browser_tools__run_playwright_script ... ERR_EMPTY_RESPONSE` screenshot/connectivity failure and reduce confusion when Playwright cannot reach a local server. 
- Add repeatable utilities and a minimal demo UI so contributors can run and smoke-test the prototype locally without guessing paths or commands.

### Description
- Added a troubleshooting section to `README.md` explaining causes of `ERR_EMPTY_RESPONSE` and a step-by-step fix using `python3 -m http.server` and matching port forwarding/URLs. 
- Added root helper `run_app.sh` which delegates to `./scripts/run_app.sh` and prints usage hints when invoked outside the repo root. 
- Added scripts: `scripts/run_app.sh` (serve the repo on a given port), `scripts/test_app.sh` (start a server, curl the app, and verify key UI tokens), `scripts/check_repo.zsh` (verify expected repo layout), and `scripts/setup_repo_folder.sh` (workspace bootstrap helper). 
- Added a demo front-end at `Cats/index.html` to visualize the UI and an extensive `IMPLEMENTATION_PACKAGE.md` with DB DDL, API contracts, UI form specs, and onboarding/run instructions.

### Testing
- Confirmed local server startup and connectivity by running `python3 -m http.server 8095 --directory /workspace/hello-world` and verifying `curl -I http://127.0.0.1:8095/Cats/` returned `HTTP/1.0 200 OK` (success). 
- Executed the server+curl wrapper (`python3 -m http.server ...; curl -I ...`) used to validate the Playwright troubleshooting steps and observed the expected HTTP 200 response (success). 
- Added `scripts/test_app.sh` which can be run to perform an automated smoke test (start server, assert HTTP 200, and check presence of UI tokens) for future CI or local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993d0fc92d4832dad72eeb028b061f3)